### PR TITLE
Add function to check Appstore application's existence

### DIFF
--- a/app/src/main/java/ai/elimu/common/utils/ui/MainActivity.kt
+++ b/app/src/main/java/ai/elimu/common/utils/ui/MainActivity.kt
@@ -1,5 +1,6 @@
 package ai.elimu.common.utils.ui
 
+import ai.elimu.common.utils.checkIfAppstoreIsInstalled
 import ai.elimu.common.utils.data.model.tts.QueueMode
 import ai.elimu.common.utils.databinding.ActivityMainBinding
 import ai.elimu.common.utils.viewmodel.TextToSpeechViewModel
@@ -52,5 +53,8 @@ class MainActivity: AppCompatActivity() {
             }
 
         })
+
+        val isAppstoreInstalled = checkIfAppstoreIsInstalled("ai.elimu.appstore.debug")
+        Log.d(TAG, "isAppstoreInstalled: $isAppstoreInstalled")
     }
 }

--- a/utils/src/main/AndroidManifest.xml
+++ b/utils/src/main/AndroidManifest.xml
@@ -1,4 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <queries>
+        <package android:name="ai.elimu.appstore" />
+        <package android:name="ai.elimu.appstore.debug" />
+    </queries>
+
 </manifest>

--- a/utils/src/main/java/ai/elimu/common/utils/ContextExt.kt
+++ b/utils/src/main/java/ai/elimu/common/utils/ContextExt.kt
@@ -6,6 +6,7 @@ import android.content.pm.PackageInfo
 import android.content.pm.PackageManager
 import android.util.Log
 import androidx.appcompat.app.AlertDialog
+import androidx.core.net.toUri
 
 fun Context.isPackageInstalled(packageName: String,
                                launchPackage: String,
@@ -31,6 +32,34 @@ fun Context.isPackageInstalled(packageName: String,
                 } catch (e: Exception) {
                     e.printStackTrace()
                     Log.e("isPackageInstalled", "startActivity exception: " + e.message)
+                }
+            }
+            .setCancelable(false)
+            .create().show()
+        return false
+    }
+}
+
+fun Context.checkIfAppstoreIsInstalled(appStoreId: String): Boolean {
+    try {
+        val packageInfoAppstore: PackageInfo =
+            packageManager.getPackageInfo(appStoreId, 0)
+        Log.i("checkIfAppstoreIsInstalled",
+            "packageInfoAppstore.versionCode: " + packageInfoAppstore.versionCode)
+        return true
+    } catch (e: PackageManager.NameNotFoundException) {
+        Log.e("checkIfAppstoreIsInstalled","getPackageInfo exception: " + e.message, e)
+        AlertDialog.Builder(this)
+            .setMessage(this.getString(R.string.appstore_needed))
+            .setPositiveButton(this.getString(R.string.download)
+            ) { _, _ ->
+                val openDownloadPage = Intent(Intent.ACTION_VIEW,
+                    "https://github.com/elimu-ai/appstore/releases".toUri())
+                try {
+                    startActivity(openDownloadPage)
+                } catch (e: Exception) {
+                    e.printStackTrace()
+                    Log.e("checkIfAppstoreIsInstalled", "startActivity exception: " + e.message)
                 }
             }
             .setCancelable(false)

--- a/utils/src/main/res/values/strings.xml
+++ b/utils/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="appstore_needed">You need to download elimu.ai Appstore first.</string>
+    <string name="appstore_needed">You need to download the elimu.ai Appstore first.</string>
     <string name="download">Download</string>
 </resources>

--- a/utils/src/main/res/values/strings.xml
+++ b/utils/src/main/res/values/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="appstore_needed">You need to download elimu.ai Appstore first.</string>
+    <string name="download">Download</string>
+</resources>


### PR DESCRIPTION
Add function to check Appstore application's existence.
Related thread: https://github.com/elimu-ai/vitabu/pull/171

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The app now verifies that the required app store is installed on your device.
  - If the app store is missing, you’ll receive an alert message and an option to download it for a seamless experience.
  - New string resources have been added for better localization and user interface management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->