### PR TITLE
Provide Default implementation of LanguageProvider

### DIFF
--- a/app/src/main/java/ai/elimu/common/utils/DataModule.kt
+++ b/app/src/main/java/ai/elimu/common/utils/DataModule.kt
@@ -1,16 +1,22 @@
 package ai.elimu.common.utils
 
 import ai.elimu.common.utils.data.repository.language.LanguageProvider
+import ai.elimu.common.utils.di.StringKey.LANGUAGE_CUSTOM
 import ai.elimu.common.utils.repository.LanguageProviderImpl
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import dagger.multibindings.IntoMap
+import dagger.multibindings.StringKey
+import java.util.Optional
 
 @Module
 @InstallIn(SingletonComponent::class)
 object DataModule {
 
+    @StringKey(LANGUAGE_CUSTOM)
+    @IntoMap
     @Provides
-    fun providesLanguageProvider(): LanguageProvider = LanguageProviderImpl()
+    fun providesLanguageProvider(): Optional<LanguageProvider> = Optional.of(LanguageProviderImpl())
 }

--- a/app/src/main/java/ai/elimu/common/utils/repository/LanguageProviderImpl.kt
+++ b/app/src/main/java/ai/elimu/common/utils/repository/LanguageProviderImpl.kt
@@ -6,7 +6,7 @@ import javax.inject.Inject
 
 class LanguageProviderImpl @Inject constructor(): LanguageProvider {
     override fun getLanguage(): String {
-        return ""
+        return "tha"
     }
 
     override fun getContentProviderId(): String {

--- a/utils/src/main/java/ai/elimu/common/utils/data/repository/DefaultLanguageProviderImpl.kt
+++ b/utils/src/main/java/ai/elimu/common/utils/data/repository/DefaultLanguageProviderImpl.kt
@@ -1,0 +1,13 @@
+package ai.elimu.common.utils.data.repository
+
+import ai.elimu.common.utils.data.repository.language.LanguageProvider
+
+class DefaultLanguageProviderImpl: LanguageProvider {
+    override fun getLanguage(): String {
+        return ""
+    }
+
+    override fun getContentProviderId(): String {
+        return "ai.elimu.content_provider"
+    }
+}

--- a/utils/src/main/java/ai/elimu/common/utils/di/DataModule.kt
+++ b/utils/src/main/java/ai/elimu/common/utils/di/DataModule.kt
@@ -1,10 +1,13 @@
 package ai.elimu.common.utils.di
 
+import ai.elimu.common.utils.data.repository.DefaultLanguageProviderImpl
 import ai.elimu.common.utils.data.repository.TextToSpeechRepository
 import ai.elimu.common.utils.data.repository.TextToSpeechRepositoryImpl
 import ai.elimu.common.utils.data.repository.language.LanguageProvider
 import ai.elimu.common.utils.data.repository.local.LocalTextToSpeechDataSource
 import ai.elimu.common.utils.data.repository.local.LocalTextToSpeechDataSourceImpl
+import ai.elimu.common.utils.di.StringKey.LANGUAGE_CUSTOM
+import ai.elimu.common.utils.di.StringKey.LANGUAGE_DEFAULT
 import android.content.Context
 import android.speech.tts.TextToSpeech
 import dagger.Binds
@@ -14,6 +17,9 @@ import dagger.hilt.InstallIn
 import dagger.hilt.android.components.ViewModelComponent
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
+import dagger.multibindings.IntoMap
+import dagger.multibindings.StringKey
+import java.util.Optional
 
 // Tells Dagger this is a Dagger module
 @Module
@@ -26,9 +32,25 @@ abstract class DataModule {
     abstract fun bindLocalTTSDataSource(dataSource: LocalTextToSpeechDataSourceImpl): LocalTextToSpeechDataSource
 }
 
+object StringKey {
+    const val LANGUAGE_DEFAULT = "defaultLanguage"
+    const val LANGUAGE_CUSTOM = "customLanguage"
+}
+
 @Module
 @InstallIn(SingletonComponent::class)
 internal object TextToSpeechModule {
+
+    @StringKey(LANGUAGE_DEFAULT)
+    @Provides
+    @IntoMap
+    fun providesOptionalLanguageProvider(): Optional<LanguageProvider> = Optional.empty()
+
+    @Provides
+    fun providesLanguageProvider(providers: Map<String, @JvmSuppressWildcards Optional<LanguageProvider>>): LanguageProvider {
+        val defaultImpl = DefaultLanguageProviderImpl()
+        return providers[LANGUAGE_CUSTOM]?.orElse(defaultImpl) ?: defaultImpl
+    }
 
     @Provides
     fun providesTextToSpeech(


### PR DESCRIPTION
Provide Default implementation of `LanguageProvider`.
With these changes, client app which depends on this library can optionally implements `LanguageProvider` interface.
This reduce the complexity of integrating `common-utils` libs into depending apps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a fallback language provider to streamline language configuration.
  
- **Bug Fixes**
  - Updated the language identifier so it now returns a valid language code rather than an empty value.
  
- **Refactor**
  - Improved the internal handling of language selection, ensuring more explicit and robust configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->