### PR TITLE
Open App Store release page when it's launched without being installed

### DIFF
--- a/utils/src/main/java/ai/elimu/common/utils/ContextExt.kt
+++ b/utils/src/main/java/ai/elimu/common/utils/ContextExt.kt
@@ -24,14 +24,24 @@ fun Context.isPackageInstalled(packageName: String,
             .setMessage(dialogMessage)
             .setPositiveButton(buttonText
             ) { _, _ ->
-                val openProviderIntent = Intent().apply {
+                val openAppStoreIntent = Intent().apply {
                     setClassName(launchPackage, launchClass)
                 }
                 try {
-                    startActivity(openProviderIntent)
+                    startActivity(openAppStoreIntent)
                 } catch (e: Exception) {
                     e.printStackTrace()
                     Log.e("isPackageInstalled", "startActivity exception: " + e.message)
+                    if (launchClass == "ai.elimu.appstore.MainActivity") {
+                        val openDownloadPage = Intent(Intent.ACTION_VIEW,
+                            "https://github.com/elimu-ai/appstore/releases".toUri())
+                        try {
+                            startActivity(openDownloadPage)
+                        } catch (e: Exception) {
+                            e.printStackTrace()
+                            Log.e("isPackageInstalled", "Open AppStore release page exception: " + e.message)
+                        }
+                    }
                 }
             }
             .setCancelable(false)

--- a/utils/src/main/java/ai/elimu/common/utils/ContextExt.kt
+++ b/utils/src/main/java/ai/elimu/common/utils/ContextExt.kt
@@ -8,6 +8,11 @@ import android.util.Log
 import androidx.appcompat.app.AlertDialog
 import androidx.core.net.toUri
 
+/**
+ * Checks if a package is installed on the device.
+ * If not, open a dialog redirecting users to another app by opening an activity
+ * represented by launchPackage and launchClass.
+ */
 fun Context.isPackageInstalled(packageName: String,
                                launchPackage: String,
                                launchClass: String,

--- a/utils/src/main/java/ai/elimu/common/utils/ContextExt.kt
+++ b/utils/src/main/java/ai/elimu/common/utils/ContextExt.kt
@@ -13,11 +13,11 @@ import androidx.core.net.toUri
  * If not, open a dialog redirecting users to another app by opening an activity
  * represented by launchPackage and launchClass.
  */
-fun Context.isPackageInstalled(packageName: String,
-                               launchPackage: String,
-                               launchClass: String,
-                               dialogMessage: String,
-                               buttonText: String): Boolean {
+fun Context.ensurePackageInstalledOrPrompt(packageName: String,
+                                           launchPackage: String,
+                                           launchClass: String,
+                                           dialogMessage: String,
+                                           buttonText: String): Boolean {
     try {
         val packageInfoAppstore: PackageInfo =
             packageManager.getPackageInfo(packageName, 0)

--- a/utils/src/main/java/ai/elimu/common/utils/ContextExt.kt
+++ b/utils/src/main/java/ai/elimu/common/utils/ContextExt.kt
@@ -29,11 +29,11 @@ fun Context.isPackageInstalled(packageName: String,
             .setMessage(dialogMessage)
             .setPositiveButton(buttonText
             ) { _, _ ->
-                val openAppStoreIntent = Intent().apply {
+                val openDestinationApp = Intent().apply {
                     setClassName(launchPackage, launchClass)
                 }
                 try {
-                    startActivity(openAppStoreIntent)
+                    startActivity(openDestinationApp)
                 } catch (e: Exception) {
                     e.printStackTrace()
                     Log.e("isPackageInstalled", "startActivity exception: " + e.message)


### PR DESCRIPTION
Open App Store release page when it's launched without being installed.

Related issue: https://github.com/elimu-ai/vitabu/issues/212

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved fallback behavior when opening the AppStore; if the app cannot be launched, users are now redirected to the AppStore releases page on GitHub.
  - Enhanced error handling to ensure smoother user experience when launching the AppStore fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->