### PR TITLE
Make TTS.speak() function non suspended

### DIFF
--- a/utils/src/main/java/ai/elimu/common/utils/data/repository/TextToSpeechRepository.kt
+++ b/utils/src/main/java/ai/elimu/common/utils/data/repository/TextToSpeechRepository.kt
@@ -4,7 +4,7 @@ import ai.elimu.common.utils.data.model.tts.QueueMode
 import android.speech.tts.UtteranceProgressListener
 
 interface TextToSpeechRepository {
-    suspend fun speak(text: CharSequence, queueMode: QueueMode, utteranceId: String)
+    fun speak(text: CharSequence, queueMode: QueueMode, utteranceId: String)
     fun isSpeaking(): Boolean
     fun stop()
     fun setOnUtteranceProgressListener(listener: UtteranceProgressListener): Int

--- a/utils/src/main/java/ai/elimu/common/utils/data/repository/TextToSpeechRepositoryImpl.kt
+++ b/utils/src/main/java/ai/elimu/common/utils/data/repository/TextToSpeechRepositoryImpl.kt
@@ -9,7 +9,7 @@ class TextToSpeechRepositoryImpl @Inject constructor(
     private val localDataSource: LocalTextToSpeechDataSource,
 ): TextToSpeechRepository {
 
-    override suspend fun speak(text: CharSequence, queueMode: QueueMode, utteranceId: String) {
+    override fun speak(text: CharSequence, queueMode: QueueMode, utteranceId: String) {
         localDataSource.speak(text, queueMode, utteranceId)
     }
 

--- a/utils/src/main/java/ai/elimu/common/utils/data/repository/local/LocalTextToSpeechDataSource.kt
+++ b/utils/src/main/java/ai/elimu/common/utils/data/repository/local/LocalTextToSpeechDataSource.kt
@@ -4,7 +4,7 @@ import ai.elimu.common.utils.data.model.tts.QueueMode
 import android.speech.tts.UtteranceProgressListener
 
 interface LocalTextToSpeechDataSource {
-    suspend fun speak(text: CharSequence, queueMode: QueueMode, utteranceId: String)
+    fun speak(text: CharSequence, queueMode: QueueMode, utteranceId: String)
     fun isSpeaking(): Boolean
     fun stop()
     fun setOnUtteranceProgressListener(listener: UtteranceProgressListener): Int

--- a/utils/src/main/java/ai/elimu/common/utils/data/repository/local/LocalTextToSpeechDataSourceImpl.kt
+++ b/utils/src/main/java/ai/elimu/common/utils/data/repository/local/LocalTextToSpeechDataSourceImpl.kt
@@ -11,7 +11,7 @@ class LocalTextToSpeechDataSourceImpl @Inject constructor(
     private val tts: TextToSpeech
 ) : LocalTextToSpeechDataSource {
 
-    override suspend fun speak(text: CharSequence, queueMode: QueueMode, utteranceId: String) {
+    override fun speak(text: CharSequence, queueMode: QueueMode, utteranceId: String) {
         val params = Bundle().apply {
             putString(TextToSpeech.Engine.KEY_PARAM_UTTERANCE_ID, utteranceId)
         }

--- a/utils/src/main/java/ai/elimu/common/utils/viewmodel/TextToSpeechViewModelImpl.kt
+++ b/utils/src/main/java/ai/elimu/common/utils/viewmodel/TextToSpeechViewModelImpl.kt
@@ -62,9 +62,7 @@ class TextToSpeechViewModelImpl @Inject constructor(
      * @return {@link #ERROR} or {@link #SUCCESS} of <b>queuing</b> the speak operation.
      */
     override fun speak(text: CharSequence, queueMode: QueueMode, utteranceId: String) {
-        ioScope.launch {
-            textToSpeechRepository.speak(text, queueMode, utteranceId)
-        }
+        textToSpeechRepository.speak(text, queueMode, utteranceId)
     }
 
     /**


### PR DESCRIPTION
Make TTS.speak() function non suspended because speak() function itself is async already.

### Issue Number
Related issue: https://github.com/elimu-ai/vitabu/issues/223

### Regression Tests
<!-- Did you verify that your changes didn't break existing functionality? -->
- [ ] I tested my changes on Android 16 (API 36)
- [x] I tested my changes on Android 15 (API 35)
- [ ] I tested my changes on Android 14 (API 34)
- [ ] I tested my changes on Android 13 (API 33)
- [ ] I tested my changes on Android 12L (API 32)
- [ ] I tested my changes on Android 12 (API 31)
- [ ] I tested my changes on Android 11 (API 30)
- [ ] I tested my changes on Android 10 (API 29)
- [ ] I tested my changes on Android 9 (API 28)
- [ ] I tested my changes on Android 8.1 (API 27)
- [ ] I tested my changes on Android 8.0 (API 26)

### Screenshots
<!-- If this PR affects the UI, please include before/after screenshots demonstrating the change(s). -->
*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved the responsiveness of text-to-speech features by making speech actions execute synchronously rather than asynchronously. This change streamlines the speech process for end-users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->